### PR TITLE
fix: add MaxAuthTries

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -18,6 +18,7 @@ ListenAddress 0.0.0.0
 ListenAddress ::
 HostKey /ssh/ssh_host_key
 HostCertificate $BASTION_HOST_CERT_PATH
+MaxAuthTries 25
 PermitRootLogin no
 PasswordAuthentication no
 PermitEmptyPasswords no


### PR DESCRIPTION
The connection through bastion fails if a user has more than 6 certificates, because of the default MaxAuthTries. 
After trying first 6 it fails to try with the seventh certificate and the connection ain't got established.

This commit sets MaxAuthTries to 25